### PR TITLE
depth を考慮して y 座標を修正

### DIFF
--- a/src/cancel.satyh
+++ b/src/cancel.satyh
@@ -20,7 +20,7 @@ end = struct
       [
         draw-text (x, y) ib;
         stroke thickness color
-          (Gr.line (x -' 2pt, y -' 2pt) (x +' w +' 2pt, y +' h +' 2pt));
+          (Gr.line (x -' 2pt, y -' d -' 2pt) (x +' w +' 2pt, y +' h +' 2pt));
       ]
     )
 
@@ -33,9 +33,9 @@ end = struct
       [
         draw-text (x, y) ib;
         stroke thickness color
-          (Gr.line (x -' 2pt, y -' 2pt) (x +' w +' 2pt, y +' h +' 2pt));
+          (Gr.line (x -' 2pt, y -' d -' 2pt) (x +' w +' 2pt, y +' h +' 2pt));
         stroke thickness color
-          (Gr.line (x -' 2pt, y +' h +' 2pt) (x +' w +' 2pt, y -' 2pt));
+          (Gr.line (x -' 2pt, y +' h +' 2pt) (x +' w +' 2pt, y -' d -' 2pt));
       ]
     )
 


### PR DESCRIPTION
斜線が 2 点 `(x -' 2pt, y -' 2pt)` と `(x +' w +' 2pt, y +' h +' 2pt)` を結んでおり， depth が入っていなかったので，前者を `(x -' 2pt, y -' d -' 2pt)` に修正しました．